### PR TITLE
Supporting GeoServer integration using multi-machine Vagrant configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 2. `cd geo-concerns-vagrant`
 3. `vagrant up`
 
-You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localhost`
+You can shell into the GeoConcerns machine with `vagrant ssh geoconcerns`, and into the GeoServer machine with `vagrant ssh geoserver`
 
 ## Using GeoConcerns
 
@@ -24,12 +24,16 @@ You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localh
         * Enter your username and password, and click "Sign up" to create your account and sign in.
 	* Once signed in, you can create content by clicking the "+" button in the upper right.
 
+## Using GeoServer
+* Access the server at [http://localhost:8181/geoserver/web/](http://localhost:8181/geoserver/web/).
+
 ## Environment
 
 * Ubuntu 14.04 64-bit base machine
 * A stock [Geo Concerns](https://github.com/projecthydra-labs/geo_concerns) app which can be run at: [http://localhost:3000](http://localhost:3000)
 * [Solr](http://lucene.apache.org/solr/): [http://localhost:8983/solr/](http://localhost:8983/solr/)
 * [Fedora](http://fedorarepository.org/): [http://localhost:8984/](http://localhost:8984/)
+* [GeoServer](http://geoserver.org/) will be run at: [http://localhost:8181/geoserver/web/](http://localhost:8181/geoserver/web/)
 
 ## Build a Demo Vagrant Box
 A script for building a reusable geo-concerns vagrant box is included.
@@ -42,4 +46,4 @@ After building the box, you can move the `demo/` directory to another location (
 
 ## Thanks
 
-This VM is a modified version of [curation-concerns-vagrant](https://github.com/projecthydra-labs/curation-concerns-vagrant). Thanks to @escowles and the other contributors to that project.
+The GeoConcerns VM is a modified version of [curation-concerns-vagrant](https://github.com/projecthydra-labs/curation-concerns-vagrant). Thanks to @escowles and the other contributors to that project.  The GeoServer VM is is the work of @drh-stanford and members of the Stanford University Libraries.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# geo-concerns-vagrant
-
+# GeoConcerns Vagrant Box
+## A Vagrant Box for the [GeoConcerns](https://github.com/projecthydra-labs/geo_concerns) Hydra-based Rails engine.
 ## Requirements
 
 * [Vagrant](https://www.vagrantup.com/)
@@ -13,16 +13,16 @@
 
 You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localhost`
 
-## Using Geo Concerns
+## Using GeoConcerns
 
-* A stock [Geo Concerns](https://github.com/projecthydra-labs/geo_concerns) app is built in the Vagrant in `/home/vagrant/geo-concerns-demo`
-  * Once connected to the Vagrant VM, start with: 
-  * `cd geo-concerns-demo; rake demo:servers`
-* Access the app at [http://localhost:3000](http://localhost:3000).
-* To setup an initial user account:
-  * Click "Log In" in the upper right, and then "Sign up" in the login form.
-  * Enter your username and password, and click "Sign up" to create your account and sign in.
-* Once signed in, you can create content by clicking the "+" button in the upper right.
+* A stock [GeoConcerns](https://github.com/projecthydra-labs/geo_concerns) app is built in the Vagrant in `/home/vagrant/geo-concerns-demo`
+  * Once connected to the Vagrant VM, start with:
+    * `cd geo-concerns-demo; rake demo:servers`
+    * Access the app at [http://localhost:3000](http://localhost:3000).
+    * To setup an initial user account:
+      * Click "Log In" in the upper right, and then "Sign up" in the login form.
+        * Enter your username and password, and click "Sign up" to create your account and sign in.
+	* Once signed in, you can create content by clicking the "+" button in the upper right.
 
 ## Environment
 
@@ -36,11 +36,10 @@ A script for building a reusable geo-concerns vagrant box is included.
 
 1. `./build-demo.sh` (this will take some time to complete)
 2. `cd demo/`
-3. Instructions for starting the machine are the same as above. 
+3. Instructions for starting the machine are the same as above.
 
 After building the box, you can move the `demo/` directory to another location (such as thumb dive), or leave it in place. All that is needed is the `geo-concerns.box` file and the `Vagrantfile`.
 
 ## Thanks
 
 This VM is a modified version of [curation-concerns-vagrant](https://github.com/projecthydra-labs/curation-concerns-vagrant). Thanks to @escowles and the other contributors to that project.
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,17 +6,31 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.box = "geoconcerns/geo-concerns-vagrant-base"
+  config.vm.define "geoconcerns", primary: true do |geoconcerns|
+    geoconcerns.vm.box = "geoconcerns/geo-concerns-vagrant-base"
 
-  config.vm.network :forwarded_port, guest: 3000, host: 3000 # Rails
-  config.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr 5.4
-  config.vm.network :forwarded_port, guest: 8984, host: 8984 # Fedora 4.5
+    geoconcerns.vm.network :forwarded_port, guest: 3000, host: 3000 # Rails
+    geoconcerns.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr 5.4
+    geoconcerns.vm.network :forwarded_port, guest: 8984, host: 8984 # Fedora 4.5
 
-  config.vm.provider "virtualbox" do |v|
-    v.memory = 2048
+    geoconcerns.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+    end
+
+    shared_dir = "/vagrant"
+
+    geoconcerns.vm.provision "shell", path: "./install_scripts/geo-concerns.sh", args: shared_dir, privileged: false
   end
 
-  shared_dir = "/vagrant"
+  config.vm.define "geoserver", primary: true do |geoserver|
+    geoserver.vm.box = "geoconcerns/geoserver-vagrant"
 
-  config.vm.provision "shell", path: "./install_scripts/geo-concerns.sh", args: shared_dir, privileged: false
+    geoserver.vm.network :forwarded_port, guest: 8080, host: 8181
+
+    geoserver.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+    end
+
+    shared_dir = "/vagrant"
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.hostname = "geoconcerns"
-
   config.vm.box = "geoconcerns/geo-concerns-vagrant-base"
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000 # Rails

--- a/build-demo.sh
+++ b/build-demo.sh
@@ -10,10 +10,6 @@ cp -R install_scripts/ demo/install_scripts
 cp Vagrantfile demo/
 cd demo
 
-# Use 32 bit base for the demo. Command works on Mac and GNU sed
-# Comment this line out if you want to build for 64bit.
-sed -i.bak 's/trusty64/trusty32/g' Vagrantfile && rm Vagrantfile.bak
-
 # Build and package the box
 vagrant up
 vagrant package --output geo-concerns.box

--- a/install_scripts/Rakefile
+++ b/install_scripts/Rakefile
@@ -9,11 +9,11 @@ require 'solr_wrapper/rake_task'
 require 'fcrepo_wrapper/rake_task'
 
 namespace :demo do
-  desc "Run Fedora, Solr, and Unicorn GeoConcerns"
+  desc "Run Fedora, Solr, and Puma for the App."
   task :servers do
     with_server 'development' do
       begin
-        `rails s -b 0.0.0.0 -d`
+        `rails s -b 0.0.0.0`
       rescue Interrupt
         puts "Shutting down..."
       end


### PR DESCRIPTION
Dear @drh-stanford  @eliotjordan and @johnhuck 

This should pull the release of geoserver-vagrant from Atlas, and deploy this into a multi-machine environment.  I have also attempted to update the README accordingly.

As a brief warning, please note that one can encounter resource consumption issues which would lead to errors such as https://www.virtualbox.org/ticket/11127.  I could only resolve this by deleting any number of downloaded/cached Vagrant Boxes (`vagrant box list; vagrant box remove [BOX_NAME]`).  After removing some critical threshold, the error could not be reproduced.
